### PR TITLE
[CHF-38] Fix: Added trailing slash to user authentication routes

### DIFF
--- a/services/user.service.tsx
+++ b/services/user.service.tsx
@@ -7,7 +7,7 @@ const pathPrefix = 'users/'
 async function signup(userData: NewUserDto) {
   return BaseService.request(
     pathPrefix,
-    'signup',
+    'signup/',
     BaseService.RequestMethod.Post,
     JSON.stringify(userData)
   )
@@ -16,7 +16,7 @@ async function signup(userData: NewUserDto) {
 async function signin(logUserData: LogUserDto) {
   const user = await BaseService.request(
     pathPrefix,
-    'signin',
+    'signin/',
     BaseService.RequestMethod.Post,
     JSON.stringify(logUserData)
   )
@@ -31,7 +31,7 @@ const userSubject = new BehaviorSubject(
 async function signout() {
   await BaseService.request(
     pathPrefix,
-    'signout',
+    'signout/',
     BaseService.RequestMethod.Post,
     JSON.stringify({ data: { user: UserService.userValue?.username } })
   )


### PR DESCRIPTION
## Descripción General

Se añade slash final a las rutas de signin, signout y signup, acorde al estándar de Django de que todas las rutas deben terminar en slash, para mantener compatibilidad con backend.

## Tarjeta en Jira

[CHF-38](https://tfflores.atlassian.net/browse/CHF-38)