### PR TITLE
feat: create upload-image-form-component

### DIFF
--- a/components/images/UploadImageForm.tsx
+++ b/components/images/UploadImageForm.tsx
@@ -1,0 +1,52 @@
+/* eslint-disable */
+import { useRef, useState } from 'react'
+
+export default function UploadImageForm(props: { showImagePreview: boolean }) {
+  const [imageSrc, setImageSrc] = useState<string>()
+  const [uploadData, setUploadData] = useState()
+  const fileInputRef = useRef<HTMLInputElement>(null)
+
+  const handleOnChange = (onChangeEvent: React.FormEvent) => {
+    const reader = new FileReader()
+
+    reader.onload = function (onLoadEvent) {
+      if (typeof onLoadEvent.target!.result === 'string') {
+        setImageSrc(onLoadEvent.target!.result)
+      } else {
+        setImageSrc(undefined)
+      }
+      setUploadData(undefined)
+    }
+    const target = onChangeEvent.target as HTMLInputElement
+    reader.readAsDataURL(target.files![0])
+  }
+  const handleOnSubmit = async (event: React.FormEvent) => {
+    event.preventDefault()
+
+    const files = (fileInputRef.current! as HTMLInputElement).files
+    const formData = new FormData()
+    for (let i = 0; i < files!.length || 0; i++) {
+      formData.append('file', files![i])
+    }
+
+    formData.append('upload_preset', 'recipelib')
+
+    const data = await fetch(
+      'https://api.cloudinary.com/v1_1/cahinostroza/image/upload',
+      {
+        method: 'POST',
+        body: formData,
+      }
+    ).then((r) => r.json())
+
+    setImageSrc(data.secure_url)
+    setUploadData(data)
+  }
+  return (
+    <form method="post" onChange={handleOnChange} onSubmit={handleOnSubmit}>
+      <input ref={fileInputRef} type="file" name="file" accept="image/*" />
+      {imageSrc && !uploadData && <button>Subir</button>}
+      {props.showImagePreview && <img src={imageSrc} />}
+    </form>
+  )
+}

--- a/components/images/UploadImageForm.tsx
+++ b/components/images/UploadImageForm.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable */
+// TOTO: remove eslint-disable line when the component is used
 import { useRef, useState } from 'react'
 
 export default function UploadImageForm(props: { showImagePreview: boolean }) {


### PR DESCRIPTION
## Descripción general
Se creo el componente `UploadImageForm` el cual sube una imagen a claudinary y se obtiene su url.
Tener en cuenta que se deshabilitó eslint en el archivo creado ya que el componente todavía no se utiliza en alguna parte (se dejó un comentario al respecto)

## Tarjeta en Jira
[CHF-33](https://tfflores.atlassian.net/browse/CHF-33)