### PR TITLE
[CHF-44] Hotfix for restriction in RecipeForm

### DIFF
--- a/__tests__/pages/recipes/recipe.test.tsx
+++ b/__tests__/pages/recipes/recipe.test.tsx
@@ -20,6 +20,9 @@ jest.mock('next/router', () => ({
 }))
 
 describe('recipe page', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => undefined)
+  })
   test('displays recipe when user is logged in', async () => {
     const recipe = {
       id: 1,
@@ -44,7 +47,6 @@ describe('recipe page', () => {
     expect(screen.getByText('test recipe')).toBeInTheDocument()
     expect(screen.getByText('this is a test recipe')).toBeInTheDocument()
   })
-
   test('router.push is called when user is not logged in', async () => {
     mockedRecipeService.get.mockImplementation(() => {
       throw new ApiError({ internalCode: InternalCode.AuthError })

--- a/components/forms/RecipeForm.tsx
+++ b/components/forms/RecipeForm.tsx
@@ -163,7 +163,13 @@ export default function RecipeForm(props: {
     const ingredients_ids = ingredients.map((ingredient) => {
       return ingredient.ingredient_id
     })
-    if ((new Set(ingredients_ids)).size !== ingredients_ids.length) {
+    if (!itemsInfo.length || !ingredients.length) {
+      setAlertMsg(
+        'Tu receta debe contener por lo menos una o más instrucciones y uno o más ingredientes'
+      )
+      return
+    }
+    if (new Set(ingredients_ids).size !== ingredients_ids.length) {
       setAlertMsg('No puedes tener ingredientes repetidos')
       return
     }


### PR DESCRIPTION
## Descripción general

Se arregla el formulario de creación y edición de recetas, para que incluya la restricción de mínimo un ingrediente y un item por receta.

## Detalles

- Se modifica `components/forms/RecipeForm.tsx` para añadir un bloque IF que evita que se haga Submit si es que la lista de ingredientes o la lista de items está vacía.
- Se suprime el uso de console log en uno de los tests unitarios para evitar que se imprima el error arrojado (este error es necesario para que el test pase, por ende no es necesario que se imprima en consola ya que su aparición está planificada).

## Probar cambios

Intentar crear una receta sin items, sin ingredientes o sin ambos. No debería dejar al usuario hacer eso en ninguno de esos casos. Correr los tests con `npm test` y verificar que pasen todos.

## Tarjeta en Jira
[CHF-44](https://tfflores.atlassian.net/browse/CHF-41)


