### PR TITLE
CHF 42-59/unit & integration tests

### DIFF
--- a/__tests__/components/forms/EditUserForm.test.tsx
+++ b/__tests__/components/forms/EditUserForm.test.tsx
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom'
+
+import { act, render, screen } from '@testing-library/react'
+import EditUserForm from '../../../components/forms/EditUserForm'
+
+describe('edit user form component', () => {
+  test('form gets rendered correctly', async () => {
+    await act(async () => {
+      render(
+        <EditUserForm
+          isMobile={false}
+          onEditUser={jest.fn()}
+          showAlert={false}
+        />
+      )
+    })
+
+    expect(screen.getByText('Nombre de usuario')).toBeInTheDocument()
+    expect(screen.getByText('Email')).toBeInTheDocument()
+    expect(screen.getByText('Nombre')).toBeInTheDocument()
+    expect(screen.getByText('Apellido')).toBeInTheDocument()
+    expect(screen.getByText('Descripcion')).toBeInTheDocument()
+    expect(screen.getByText('Url imagen de perfil')).toBeInTheDocument()
+    expect(screen.getByText('Editar perfil')).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/forms/IngredientContainer.test.tsx
+++ b/__tests__/components/forms/IngredientContainer.test.tsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom'
+import { MeasurementService } from '../../../services/measurement.service'
+import { IngredientService } from '../../../services/ingredient.service'
+import { act, render, screen } from '@testing-library/react'
+import IngredientContainer from '../../../components/forms/IngredientContainer'
+
+jest.mock('../../../services/measurement.service')
+const mockedMeasurementService = MeasurementService as jest.Mocked<
+  typeof MeasurementService
+>
+
+jest.mock('../../../services/ingredient.service')
+const mockedIngredientService = IngredientService as jest.Mocked<
+  typeof IngredientService
+>
+
+describe('ingredient container form component', () => {
+  mockedMeasurementService.getAllMeasurements.mockResolvedValue([
+    { id: 1, name: 'measurement 1' },
+    { id: 2, name: 'measurement 2' },
+  ])
+
+  mockedIngredientService.getAllIngredients.mockResolvedValue([
+    { id: 1, name: 'Ingredient 1' },
+    { id: 2, name: 'Ingredient 2' },
+  ])
+
+  test('form gets rendered correctly', async () => {
+    await act(async () => {
+      render(
+        <IngredientContainer
+          index={0}
+          isMobile={false}
+          info={{ quantity: null, measurement_id: null, ingredient_id: null }}
+          onChange={jest.fn()}
+          onRemove={jest.fn()}
+        />
+      )
+    })
+
+    expect(screen.getAllByText('Ingrediente').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Unidad').length).toBeGreaterThan(0)
+  })
+})

--- a/__tests__/components/forms/Item.test.tsx
+++ b/__tests__/components/forms/Item.test.tsx
@@ -1,0 +1,23 @@
+import '@testing-library/jest-dom'
+
+import { act, render, screen } from '@testing-library/react'
+import Item from '../../../components/forms/Item'
+
+describe('item form component', () => {
+  test('form gets rendered correctly', async () => {
+    await act(async () => {
+      render(
+        <Item
+          orderNumber={0}
+          onChange={jest.fn()}
+          onDelete={jest.fn()}
+          onChangeForNextItem={jest.fn()}
+          body={'Item'}
+        />
+      )
+    })
+
+    expect(screen.getByText('Item')).toBeInTheDocument()
+    expect(screen.getByText('1.')).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/forms/NewUserForm.test.tsx
+++ b/__tests__/components/forms/NewUserForm.test.tsx
@@ -1,0 +1,21 @@
+import '@testing-library/jest-dom'
+
+import { act, render, screen } from '@testing-library/react'
+import NewUserForm from '../../../components/forms/NewUserForm'
+
+describe('new user form component', () => {
+  test('form gets rendered correctly', async () => {
+    await act(async () => {
+      render(
+        <NewUserForm isMobile={false} onAddUser={jest.fn()} showAlert={false} />
+      )
+    })
+
+    expect(screen.getByText('Nombre de usuario')).toBeInTheDocument()
+    expect(screen.getByText('Email')).toBeInTheDocument()
+    expect(screen.getByText('Nombre')).toBeInTheDocument()
+    expect(screen.getByText('Apellido')).toBeInTheDocument()
+    expect(screen.getByText('Contraseña')).toBeInTheDocument()
+    expect(screen.getByText('Registrar')).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/forms/RecipeForm.test.tsx
+++ b/__tests__/components/forms/RecipeForm.test.tsx
@@ -1,0 +1,111 @@
+import '@testing-library/jest-dom'
+
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { MeasurementService } from '../../../services/measurement.service'
+import { RecipeService } from '../../../services/recipe.service'
+import { TagService } from '../../../services/tag.service'
+import RecipeForm from '../../../components/forms/RecipeForm'
+import { IngredientService } from '../../../services/ingredient.service'
+
+const mockRouterPush = jest.fn()
+
+jest.mock('next/router', () => {
+  const originalModule = jest.requireActual('next/router')
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    useRouter: () => {
+      return { push: mockRouterPush }
+    },
+  }
+})
+
+jest.mock('../../../services/measurement.service')
+const mockedMeasurementService = MeasurementService as jest.Mocked<
+  typeof MeasurementService
+>
+
+jest.mock('../../../services/tag.service')
+const mockedTagService = TagService as jest.Mocked<typeof TagService>
+
+jest.mock('../../../services/ingredient.service')
+const mockedIngredientService = IngredientService as jest.Mocked<
+  typeof IngredientService
+>
+
+jest.mock('../../../services/recipe.service')
+const mockedRecipeService = RecipeService as jest.Mocked<typeof RecipeService>
+
+const mockedRecipe = {
+  id: 1,
+  name: 'Mocked recipe',
+  picture_url: 'https://test.com',
+  description: 'A mocked recipe',
+  private: false,
+  user_id: 1,
+  items: [{ url: 'https://test.com', body: 'An item', order_number: 0 }],
+  ingredients: [
+    {
+      ingredient_id: 1,
+      measurement_id: 1,
+      ingredient_name: 'An ingredient',
+      measurement_name: 'A measurement',
+      quantity: 1,
+    },
+  ],
+  tags: [
+    { tag_id: 1, tag_name: 'A tag', tag_placeholder_url: 'https://test.com' },
+  ],
+  ratings: [{ recipe_id: 1, user_id: 1, like: true }],
+  created_at: new Date(),
+  updated_at: new Date(),
+}
+
+describe('recipe form component', () => {
+  mockedMeasurementService.getAllMeasurements.mockResolvedValue([
+    { id: 1, name: 'measurement 1' },
+    { id: 2, name: 'measurement 2' },
+  ])
+
+  mockedTagService.getAllTags.mockResolvedValue([
+    { id: 1, name: 'Tag 1' },
+    { id: 2, name: 'Tag 2' },
+  ])
+
+  mockedIngredientService.getAllIngredients.mockResolvedValue([
+    {
+      id: 1,
+      name: 'Ingredient 1',
+    },
+  ])
+
+  mockedRecipeService.edit.mockResolvedValue(mockedRecipe)
+
+  test('form gets rendered correctly', async () => {
+    await act(async () => {
+      render(<RecipeForm isMobile={false} />)
+    })
+
+    expect(screen.getByText('Nombre')).toBeInTheDocument()
+    expect(screen.getByText('Descripción')).toBeInTheDocument()
+    expect(screen.getByText('Privada')).toBeInTheDocument()
+  })
+
+  test('form displays existing recipe correctly', async () => {
+    await act(async () => {
+      render(<RecipeForm isMobile={false} recipe={mockedRecipe} />)
+    })
+
+    expect(screen.getByText('A mocked recipe')).toBeInTheDocument()
+  })
+
+  test('form submit button works correctly', async () => {
+    await act(async () => {
+      render(<RecipeForm isMobile={false} recipe={mockedRecipe} />)
+      fireEvent.click(screen.getByText('Publicar'))
+    })
+
+    expect(mockRouterPush).toBeCalled()
+  })
+})

--- a/__tests__/components/users/FollowUser.test.tsx
+++ b/__tests__/components/users/FollowUser.test.tsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom'
+
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import FollowUser from '../../../components/users/FollowUser'
+import { UserService } from '../../../services/user.service'
+
+jest.mock('../../../services/user.service')
+const mockedUserService = UserService as jest.Mocked<typeof UserService>
+
+describe('follow user component', () => {
+  mockedUserService.follow.mockResolvedValue(jest.fn())
+  mockedUserService.unfollow.mockResolvedValue(jest.fn())
+
+  test('component gets rendered correctly', async () => {
+    await act(async () => {
+      render(
+        <FollowUser
+          following={false}
+          userId={1}
+          onFollow={jest.fn()}
+          onUnfollow={jest.fn()}
+        />
+      )
+    })
+
+    expect(screen.getByText('Seguir')).toBeInTheDocument()
+  })
+
+  test('following user updates button', async () => {
+    await act(async () => {
+      render(
+        <FollowUser
+          following={false}
+          userId={1}
+          onFollow={jest.fn()}
+          onUnfollow={jest.fn()}
+        />
+      )
+      fireEvent.click(screen.getByText('Seguir'))
+    })
+
+    expect(screen.getByText('Dejar de Seguir')).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/users/LogUserForm.test.tsx
+++ b/__tests__/components/users/LogUserForm.test.tsx
@@ -1,0 +1,22 @@
+import '@testing-library/jest-dom'
+
+import { act, render, screen } from '@testing-library/react'
+import LogUserForm from '../../../components/users/LogUserForm'
+
+describe('log user form component', () => {
+  test('form gets rendered correctly', async () => {
+    await act(async () => {
+      render(
+        <LogUserForm
+          onLogUser={jest.fn()}
+          entityNotFound={false}
+          isMobile={false}
+        />
+      )
+    })
+
+    expect(screen.getByText('Nombre de usuario')).toBeInTheDocument()
+    expect(screen.getByText('Contraseña')).toBeInTheDocument()
+    expect(screen.getByText('Iniciar sesión')).toBeInTheDocument()
+  })
+})

--- a/__tests__/components/users/NewUserForm.test.tsx
+++ b/__tests__/components/users/NewUserForm.test.tsx
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom'
+
+import { act, render, screen } from '@testing-library/react'
+import NewUserForm from '../../../components/users/NewUserForm'
+
+describe('new user form component', () => {
+  test('form gets rendered correctly', async () => {
+    await act(async () => {
+      render(
+        <NewUserForm isMobile={false} onAddUser={jest.fn()} showAlert={false} />
+      )
+    })
+
+    expect(screen.getByText('Nombre de usuario')).toBeInTheDocument()
+    expect(screen.getByText('Email')).toBeInTheDocument()
+    expect(screen.getByText('Nombre')).toBeInTheDocument()
+    expect(screen.getByText('Apellido')).toBeInTheDocument()
+  })
+})

--- a/__tests__/pages/index.test.tsx
+++ b/__tests__/pages/index.test.tsx
@@ -1,0 +1,45 @@
+import '@testing-library/jest-dom'
+
+import { act, render, screen } from '@testing-library/react'
+import AuthContext from '../../contexts/auth-context'
+import Home from '../../pages'
+
+const mockRouterPush = jest.fn()
+
+jest.mock('next/router', () => {
+  const originalModule = jest.requireActual('next/router')
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    useRouter: () => {
+      return { push: mockRouterPush }
+    },
+  }
+})
+
+const mockedUser = {
+  id: 1,
+  username: 'user',
+  email: 'user@test.com',
+  first_name: 'MockedUser',
+  last_name: 'Test',
+  picture_url: 'https://test.com',
+  description: 'A mocked user',
+}
+
+describe('home page', () => {
+  test('page displays welcome text correctly', async () => {
+    await act(async () => {
+      render(
+        <AuthContext.Provider value={{ user: mockedUser }}>
+          <Home />
+        </AuthContext.Provider>
+      )
+    })
+
+    expect(
+      screen.getByText('Bienvenido MockedUser a RecipeLib')
+    ).toBeInTheDocument()
+  })
+})

--- a/__tests__/pages/profile/edit.test.tsx
+++ b/__tests__/pages/profile/edit.test.tsx
@@ -1,0 +1,34 @@
+import '@testing-library/jest-dom'
+
+import { act, render, screen } from '@testing-library/react'
+import AuthContext from '../../../contexts/auth-context'
+import NewRecipePage from '../../../pages/profile/edit'
+
+const mockedUser = {
+  id: 1,
+  username: 'user',
+  email: 'user@test.com',
+  first_name: 'MockedUser',
+  last_name: 'Test',
+  picture_url: 'https://test.com',
+  description: 'A mocked user',
+}
+
+describe('profile edit page', () => {
+  test('page user form fields', async () => {
+    await act(async () => {
+      render(
+        <AuthContext.Provider value={{ user: mockedUser }}>
+          <NewRecipePage isMobile={false} />
+        </AuthContext.Provider>
+      )
+    })
+
+    expect(screen.getByText('Nombre de usuario')).toBeInTheDocument()
+    expect(screen.getByText('Email')).toBeInTheDocument()
+    expect(screen.getByText('Apellido')).toBeInTheDocument()
+    expect(screen.getByText('Descripcion')).toBeInTheDocument()
+    expect(screen.getByText('Url imagen de perfil')).toBeInTheDocument()
+    expect(screen.getByText('Editar perfil')).toBeInTheDocument()
+  })
+})

--- a/__tests__/pages/profile/id/index.test.tsx
+++ b/__tests__/pages/profile/id/index.test.tsx
@@ -1,0 +1,51 @@
+import '@testing-library/jest-dom'
+
+import { act, render, screen } from '@testing-library/react'
+import AnotherProfilePage from '../../../../pages/profile/[id]'
+import { UserService } from '../../../../services/user.service'
+
+const mockedUser = {
+  id: 1,
+  username: 'user',
+  email: 'user@test.com',
+  first_name: 'MockedUser',
+  last_name: 'Test',
+  picture_url: 'https://test.com',
+  description: 'A mocked user',
+}
+
+const mockRouterPush = jest.fn()
+
+jest.mock('next/router', () => {
+  const originalModule = jest.requireActual('next/router')
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    useRouter: () => {
+      return { push: mockRouterPush, query: { id: '1' } }
+    },
+  }
+})
+
+jest.mock('../../../../components/recipes/Recipes', () => {
+  const Recipes = () => <div>Recipes mock</div>
+  return Recipes
+})
+
+jest.mock('../../../../services/user.service')
+const mockedUserService = UserService as jest.Mocked<typeof UserService>
+
+describe('profile id page', () => {
+  mockedUserService.show_user_by_id.mockResolvedValue(mockedUser)
+
+  test('profile show user info', async () => {
+    await act(async () => {
+      render(<AnotherProfilePage />)
+    })
+
+    expect(screen.getByText('MockedUser Test')).toBeInTheDocument()
+    expect(screen.getByText('user@test.com')).toBeInTheDocument()
+    expect(screen.getByText('A mocked user')).toBeInTheDocument()
+  })
+})

--- a/__tests__/pages/profile/index.test.tsx
+++ b/__tests__/pages/profile/index.test.tsx
@@ -1,0 +1,50 @@
+import '@testing-library/jest-dom'
+
+import { act, render, screen } from '@testing-library/react'
+import ProfilePage from '../../../pages/profile'
+import AuthContext from '../../../contexts/auth-context'
+
+const mockRouterPush = jest.fn()
+
+jest.mock('next/router', () => {
+  const originalModule = jest.requireActual('next/router')
+
+  return {
+    __esModule: true,
+    ...originalModule,
+    useRouter: () => {
+      return { push: mockRouterPush }
+    },
+  }
+})
+
+const mockedUser = {
+  id: 1,
+  username: 'user',
+  email: 'user@test.com',
+  first_name: 'MockedUser',
+  last_name: 'Test',
+  picture_url: 'https://test.com',
+  description: 'A mocked user',
+}
+
+jest.mock('../../../components/recipes/Recipes', () => {
+  const Recipes = () => <div>Recipes mock</div>
+  return Recipes
+})
+
+describe('profile main page', () => {
+  test('page shows user data', async () => {
+    await act(async () => {
+      render(
+        <AuthContext.Provider value={{ user: mockedUser }}>
+          <ProfilePage />
+        </AuthContext.Provider>
+      )
+    })
+
+    expect(screen.getByText('MockedUser Test')).toBeInTheDocument()
+    expect(screen.getByText('user@test.com')).toBeInTheDocument()
+    expect(screen.getByText('A mocked user')).toBeInTheDocument()
+  })
+})

--- a/pages/api/hello.ts
+++ b/pages/api/hello.ts
@@ -1,5 +1,0 @@
-import { NextApiRequest, NextApiResponse } from 'next'
-
-export default function Hello(_: NextApiRequest, res: NextApiResponse) {
-  return res.status(200).json({ text: 'Hello' })
-}


### PR DESCRIPTION
# Descripción
Se implementaron tests unitarios y de integración en múltiples componentes/páginas para lograr la meta de 60% de coverage:

<img width="1163" alt="Tests" src="https://user-images.githubusercontent.com/48481745/175468425-074673ee-5a8d-499a-aba1-228f0d5dea32.png">

## Observación
Resulta ser que si bien `jest` es una librería de testing unitario, los tests construidos junto a `react/testing-library` corresponden de hecho a tests de integración. 

Esto tiene sentido porque dichos tests abarcan múltiples componentes a la vez y además se abstraen de la implementación. De esta forma, al alcanzar el coverage objetivo, se está cubriendo ambos tipos de tests.

Cierra CHF-42, CHF-59